### PR TITLE
fix(ws): authenticate WebSocket via Authorization header for Jellyfin 12

### DIFF
--- a/custom_components/jellyha/ws_client.py
+++ b/custom_components/jellyha/ws_client.py
@@ -70,13 +70,25 @@ class JellyfinWebSocketClient:
         encoded_id = quote(self._device_id)
         encoded_key = quote(self._api_key)
         url = f"{url}/socket?api_key={encoded_key}&deviceId={encoded_id}"
-        
+
+        # Jellyfin 12 dropped query-string api_key auth on the API and /socket
+        # routes (image/stream routes still accept it), so the token is also sent
+        # in the Authorization header. Older servers ignore the header and use the
+        # query parameter, so sending both keeps 10.x working.
+        headers = {
+            "Authorization": f'MediaBrowser Client="Home Assistant", '
+            f'Device="HACS Integration", '
+            f'DeviceId="{self._device_id}", '
+            f'Version="1.0.0", '
+            f'Token="{self._api_key}"'
+        }
+
         retry_delay = 2  # Start with 2 seconds
         
         while not self._stop_event.is_set():
             try:
                 _LOGGER.debug("Connecting to Jellyfin WebSocket: %s", url)
-                async with self._session.ws_connect(url) as ws:
+                async with self._session.ws_connect(url, headers=headers) as ws:
                     self._ws = ws
                     self._connected = True
                     _LOGGER.info("Connected to Jellyfin WebSocket")


### PR DESCRIPTION
Fixes #23.

## Problem

On Jellyfin 12, the WebSocket handshake fails permanently with `403, message='Invalid response status'` and retries every 30s forever. Jellyfin 12 removed query-string `api_key` authentication on the API and `/socket` routes, and `ws_client.py` is the only place in the integration that authenticates that way — `api.py` already uses the `Authorization` header everywhere else.

The failure is quiet. REST keeps working, so entities still update via the polling fallback and the integration looks healthy; it has just silently dropped from `local_push` to polling while emitting ~120 error lines/hour.

It also mis-signals. Jellyfin logs `Token is required`, not "invalid token" — the server never parses a credential, so a perfectly valid API key looks revoked. Regenerating the key does not help; a fresh key fails identically.

## Change

Build the same `MediaBrowser ... Token="..."` header that `api.py::_headers` already constructs and pass it to `ws_connect`.

The `api_key` query parameter is deliberately **kept**, so this is not a breaking change for anyone on Jellyfin 10.x: old servers read the query parameter and ignore the header, new servers read the header. Verified that sending both connects successfully on 12.0.0.

## Verification

Against Jellyfin 12.0.0, using the integration's own aiohttp session semantics:

```
query param only    -> WSServerHandshakeError 403, 'Invalid response status'
Authorization hdr   -> CONNECTED
both (this PR)      -> CONNECTED
                       first frame: {"MessageId":"...","Data":60,"MessageType":"ForceKeepAlive"}
```

Deployed to a live Home Assistant instance running JellyHA 1.2.0 against Jellyfin 12.0.0: the 30s retry loop stops and `Connected to Jellyfin WebSocket` appears on startup.

Supporting evidence that the token was never the problem — same token, same server:

```
GET /System/Info?api_key=<TOKEN>                                  -> 401
GET /System/Info   (Authorization: MediaBrowser Token="<TOKEN>")  -> 200
GET /System/Info   (no auth at all)                               -> 401
```

Image and stream routes still accept the query parameter (`200` / `206`), which is why only the socket broke.

## Note for a future cleanup

`_LOGGER.debug("Connecting to Jellyfin WebSocket: %s", url)` writes the API token into debug logs, because the token is in the URL. Once 10.x support is no longer needed and the query parameter can be dropped, that exposure goes away. Left alone here to keep this PR to the single fix.

https://claude.ai/code/session_017T4H53VDcUpFTMCX7Af77t
